### PR TITLE
Fix colophon link to SE page

### DIFF
--- a/src/epub/text/colophon.xhtml
+++ b/src/epub/text/colophon.xhtml
@@ -36,7 +36,7 @@
 			The first edition was released on<br/>
 			<span class="release-date">May 12, 2015, 12:01 <abbr class="time eoc">a.m.</abbr></span><br/>
 			You can check for updates to this ebook, view its revision history, or download it for different ereading systems at<br/>
-			<a class="raw-url" href="https://standardebooks.org/ebooks/niccolo-machiavelli">standardebooks.org/ebooks/h-g-wells/the-time-machine</a>.</p>
+			<a class="raw-url" href="https://standardebooks.org/ebooks/h-g-wells/the-time-machine">standardebooks.org/ebooks/h-g-wells/the-time-machine</a>.</p>
 			<p>The volunteer-driven Standard Ebooks project relies on readers like you to submit typos, corrections, and other improvements. Anyone can contribute at <a class="raw-url" href="https://standardebooks.org">standardebooks.org</a>.</p>
 		</section>
 	</body>


### PR DESCRIPTION
Looks like the link was accidentally left as original when the title was updated.